### PR TITLE
do not use build arg for base image version

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,9 +225,9 @@ Output from `ci/test` resembles:
     [RUN] docker_rm fixtures
 
     ===> Create data container in which to download test files.
-    [RUN] docker create --name downloads -v /home/user ${BASE_IMAGE} true
+    [RUN] docker create --name downloads -v /home/user base_image true
     19d787a81fa8cc3d68fdd97f0d7fa85d2d3f95fadcd144e52f47aafda74fb763
-    [RUN] docker run --rm --volumes-from downloads ${BASE_IMAGE} chown -R 1000:1000 /home/user
+    [RUN] docker run --rm --volumes-from downloads base_image chown -R 1000:1000 /home/user
 
     ===> Create data container for fixtures.
     [RUN] docker create --name fixtures hooktftp-fixtures true

--- a/ci/build
+++ b/ci/build
@@ -2,7 +2,6 @@
 set -e
 
 cat >ci/vars <<EOF
-export BASE_IMAGE='alpine:3.10.1'
 export BUILD_DATE="$(date +%Y%m%dT%H%M)"
 export VCS_REF="$(git rev-parse --short HEAD)"
 export TAG="$(date +%Y%m%dT%H%M)-git-\${VCS_REF}"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,9 +12,14 @@ networks:
           gateway: 192.168.254.1
 
 services:
+  base_image:
+    image: base_image
+    build:
+      context: src/alpine/base/
+
   # Data container in which to download test files.
   downloads:
-    image: ${BASE_IMAGE}
+    image: base_image
     volumes:
       - /home/user/
     command: chown -R 1000:1000 /home/user
@@ -24,15 +29,12 @@ services:
     image: hooktftp_fixtures
     build:
       context: fixtures/
-      args:
-        - BASE_IMAGE
 
   tftpd:
     image: hooktftp-runtime
     build:
       context: src/alpine/builder/
       args:
-        - BASE_IMAGE
         - BUILD_DATE
         - CIRCLE_BUILD_URL
         - HOOKTFTP_VERSION
@@ -56,8 +58,6 @@ services:
     image: tftp
     build:
       context: src/alpine/client/
-      args:
-        - BASE_IMAGE
     volumes_from:
       - downloads
     networks:
@@ -66,13 +66,13 @@ services:
       - internal.example.com:192.168.254.254
 
   test:
-    image: ${BASE_IMAGE}
+    image: base_image
     volumes_from:
       - downloads
     entrypoint: test
 
   list_files_in_tftpboot:
-    image: ${BASE_IMAGE}
+    image: base_image
     volumes_from:
       - tftpd
     command: ls -1 -R /tftpboot/

--- a/fixtures/Dockerfile
+++ b/fixtures/Dockerfile
@@ -1,5 +1,4 @@
-ARG BASE_IMAGE
-FROM ${BASE_IMAGE}
+FROM base_image
 COPY . /tftpboot/site
 VOLUME ["/tftpboot/site"]
 ENTRYPOINT ["/bin/true"]

--- a/src/alpine/base/Dockerfile
+++ b/src/alpine/base/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.10.1

--- a/src/alpine/builder/Dockerfile
+++ b/src/alpine/builder/Dockerfile
@@ -1,5 +1,4 @@
-ARG BASE_IMAGE
-FROM ${BASE_IMAGE} as builder
+FROM base_image as builder
 
 RUN apk add --no-cache \
       busybox-extras \

--- a/src/alpine/client/Dockerfile
+++ b/src/alpine/client/Dockerfile
@@ -1,5 +1,4 @@
-ARG BASE_IMAGE
-FROM ${BASE_IMAGE}
+FROM base_image
 
 # Install dependencies.
 RUN apk add --no-cache tftp-hpa

--- a/test/functional_tests.bats
+++ b/test/functional_tests.bats
@@ -5,7 +5,7 @@ load functions
   [[ ${output} =~ 'Dropped privileges' ]]
 
   cid=$(docker-compose ps -q tftpd)
-  docker run --rm -it --pid container:${cid} --network container:${cid} "${BASE_IMAGE}" ps -o pid,user,group,comm |
+  docker run --rm -it --pid container:${cid} --network container:${cid} base_image ps -o pid,user,group,comm |
   grep -E '1 1000     1000     hooktftp'
 }
 


### PR DESCRIPTION
This partially unwinds commit c8730674191f39e3ac24687a1ed30d205 and
intends to support the addition of renovate-bot for automatic updates.